### PR TITLE
Fix: Handling non-serializable error details in response logs

### DIFF
--- a/server.py
+++ b/server.py
@@ -109,7 +109,7 @@ OPENAI_MODELS = [
 # List of Gemini models
 GEMINI_MODELS = [
     "gemini-2.5-pro-preview-03-25",
-    "gemini-2.0-flash"
+    "gemini-2.5-flash-preview-04-17"
 ]
 
 # Helper function to clean schema for Gemini
@@ -1321,7 +1321,23 @@ async def create_message(
                     error_details[key] = str(value)
         
         # Log all error details
-        logger.error(f"Error processing request: {json.dumps(error_details, indent=2)}")
+        # logger.error(f"Error processing request: {json.dumps(error_details, indent=2)}")
+        if isinstance(error_details, dict):
+            # Filter out non-serializable objects or convert them to strings
+            serializable_details = {}
+            for key, value in error_details.items():
+                try:
+                    # Try to see if it's JSON serializable
+                    json.dumps({key: value})
+                    serializable_details[key] = value
+                except TypeError:
+                    # If not, convert to string representation
+                    serializable_details[key] = f"<{type(value).__name__}>: {str(value)}"
+
+            logger.error(f"Error processing request: {json.dumps(serializable_details, indent=2)}")
+        else:
+            # If it's not a dict, just log it as a string
+            logger.error(f"Error processing request: {str(error_details)}")
         
         # Format error for response
         error_message = f"Error: {str(e)}"


### PR DESCRIPTION
# Fix: Handling non-serializable error details in response logs

## Problem
When exceptions occur during request processing, the error logging mechanism attempts to serialize error details as JSON using `json.dumps()`. However, some error objects contain non-serializable Python objects, which causes secondary exceptions during error handling and prevents proper error information from being logged.

## Changes
This PR addresses two issues:

1. **Improved error object serialization:** Added a mechanism to detect and handle non-serializable objects in error details by converting them to string representations before JSON serialization.

2. **Updated Gemini model list:** Changed `gemini-2.0-flash` to `gemini-2.5-flash-preview-04-17` in the supported Gemini models list to reflect the current available models.

## Implementation
- Added type checking and exception handling when serializing error details
- Implemented fallback to string representation for non-serializable objects
- Properly formatted type information for better debugging

## Testing
The changes have been tested with gemini 2.5 pro and flash models, scanning a full repo and generating files using Claude Code. 
No errors shown after the fix.