### PR TITLE
Fixed repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ A proxy server that lets you use Anthropic clients with Gemini or OpenAI models 
 
 1. **Clone this repository**:
    ```bash
-   git clone https://github.com/1rgs/claude-code-openai.git
-   cd claude-code-openai
+   git clone https://github.com/1rgs/claude-code-proxy.git
+   cd claude-code-proxy
    ```
 
 2. **Install uv** (if you haven't already):


### PR DESCRIPTION
I'm guessing the repo used to be called `claude-code-openai` but the docs weren't fully updated when the name changed to `claude-code-proxy`