### PR TITLE
Add "transparent Anthropic proxy" mode with PREFERRED_PROVIDER=anthropic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,18 +4,24 @@ OPENAI_API_KEY="sk-..."
 GEMINI_API_KEY="your-google-ai-studio-key"
 
 # Optional: Provider Preference and Model Mapping
-# Controls which provider (google or openai) is preferred for mapping haiku/sonnet.
+# Controls which provider (google, openai, or anthropic) is preferred for mapping haiku/sonnet.
 # Defaults to openai if not set.
+# Set to "anthropic" for "just an Anthropic proxy" mode (no remapping)
 PREFERRED_PROVIDER="openai"
 
 # Optional: Specify the exact models to map haiku/sonnet to.
 # If PREFERRED_PROVIDER=google, these MUST be valid Gemini model names known to the server.
 # Defaults to gemini-2.5-pro-preview-03-25 and gemini-2.0-flash if PREFERRED_PROVIDER=google.
 # Defaults to gpt-4.1 and gpt-4.1-mini if PREFERRED_PROVIDER=openai.
+# These are IGNORED when PREFERRED_PROVIDER=anthropic (models are not remapped).
 # BIG_MODEL="gpt-4.1"
 # SMALL_MODEL="gpt-4.1-mini"
 
 # Example Google mapping:
 # PREFERRED_PROVIDER="google"
 # BIG_MODEL="gemini-2.5-pro-preview-03-25"
-# SMALL_MODEL="gemini-2.0-flash" 
+# SMALL_MODEL="gemini-2.0-flash"
+
+# Example "just an Anthropic proxy" mode:
+# PREFERRED_PROVIDER="anthropic"
+# (BIG_MODEL and SMALL_MODEL are ignored in this mode)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ PREFERRED_PROVIDER="anthropic"
 # haiku/sonnet requests are passed directly to Anthropic models
 ```
 
+*Use case: This mode enables you to use the proxy infrastructure (for logging, middleware, request/response processing, etc.) while still using actual Anthropic models rather than being forced to remap to OpenAI or Gemini.*
+
 **Example 4: Use Specific OpenAI Models**
 ```dotenv
 OPENAI_API_KEY="your-openai-key"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Anthropic API Proxy for Gemini & OpenAI Models 🔄
 
-**Use Anthropic clients (like Claude Code) with Gemini or OpenAI backends.** 🤝
+**Use Anthropic clients (like Claude Code) with Gemini, OpenAI, or direct Anthropic backends.** 🤝
 
-A proxy server that lets you use Anthropic clients with Gemini or OpenAI models via LiteLLM. 🌉
+A proxy server that lets you use Anthropic clients with Gemini, OpenAI, or Anthropic models themselves (a transparent proxy of sorts), all via LiteLLM. 🌉
 
 
 ![Anthropic API Proxy](pic.png)
@@ -39,13 +39,14 @@ A proxy server that lets you use Anthropic clients with Gemini or OpenAI models 
    *   `ANTHROPIC_API_KEY`: (Optional) Needed only if proxying *to* Anthropic models.
    *   `OPENAI_API_KEY`: Your OpenAI API key (Required if using the default OpenAI preference or as fallback).
    *   `GEMINI_API_KEY`: Your Google AI Studio (Gemini) API key (Required if PREFERRED_PROVIDER=google).
-   *   `PREFERRED_PROVIDER` (Optional): Set to `openai` (default) or `google`. This determines the primary backend for mapping `haiku`/`sonnet`.
-   *   `BIG_MODEL` (Optional): The model to map `sonnet` requests to. Defaults to `gpt-4.1` (if `PREFERRED_PROVIDER=openai`) or `gemini-2.5-pro-preview-03-25`.
-   *   `SMALL_MODEL` (Optional): The model to map `haiku` requests to. Defaults to `gpt-4.1-mini` (if `PREFERRED_PROVIDER=openai`) or `gemini-2.0-flash`.
+   *   `PREFERRED_PROVIDER` (Optional): Set to `openai` (default), `google`, or `anthropic`. This determines the primary backend for mapping `haiku`/`sonnet`.
+   *   `BIG_MODEL` (Optional): The model to map `sonnet` requests to. Defaults to `gpt-4.1` (if `PREFERRED_PROVIDER=openai`) or `gemini-2.5-pro-preview-03-25`. Ignored when `PREFERRED_PROVIDER=anthropic`.
+   *   `SMALL_MODEL` (Optional): The model to map `haiku` requests to. Defaults to `gpt-4.1-mini` (if `PREFERRED_PROVIDER=openai`) or `gemini-2.0-flash`. Ignored when `PREFERRED_PROVIDER=anthropic`.
 
    **Mapping Logic:**
    - If `PREFERRED_PROVIDER=openai` (default), `haiku`/`sonnet` map to `SMALL_MODEL`/`BIG_MODEL` prefixed with `openai/`.
    - If `PREFERRED_PROVIDER=google`, `haiku`/`sonnet` map to `SMALL_MODEL`/`BIG_MODEL` prefixed with `gemini/` *if* those models are in the server's known `GEMINI_MODELS` list (otherwise falls back to OpenAI mapping).
+   - If `PREFERRED_PROVIDER=anthropic`, `haiku`/`sonnet` requests are passed directly to Anthropic with the `anthropic/` prefix without remapping to different models.
 
 4. **Run the server**:
    ```bash
@@ -132,7 +133,15 @@ PREFERRED_PROVIDER="google"
 # SMALL_MODEL="gemini-2.0-flash" # Optional, it's the default for Google pref
 ```
 
-**Example 3: Use Specific OpenAI Models**
+**Example 3: Use Direct Anthropic ("Just an Anthropic Proxy" Mode)**
+```dotenv
+ANTHROPIC_API_KEY="sk-ant-..."
+PREFERRED_PROVIDER="anthropic"
+# BIG_MODEL and SMALL_MODEL are ignored in this mode
+# haiku/sonnet requests are passed directly to Anthropic models
+```
+
+**Example 4: Use Specific OpenAI Models**
 ```dotenv
 OPENAI_API_KEY="your-openai-key"
 GEMINI_API_KEY="your-google-key"

--- a/server.py
+++ b/server.py
@@ -205,8 +205,13 @@ class MessagesRequest(BaseModel):
 
         # --- Mapping Logic --- START ---
         mapped = False
+        if PREFERRED_PROVIDER == "anthropic":
+            # Don't remap to big/small models, just add the prefix
+            new_model = f"anthropic/{clean_v}"
+            mapped = True
+
         # Map Haiku to SMALL_MODEL based on provider preference
-        if 'haiku' in clean_v.lower():
+        elif 'haiku' in clean_v.lower():
             if PREFERRED_PROVIDER == "google" and SMALL_MODEL in GEMINI_MODELS:
                 new_model = f"gemini/{SMALL_MODEL}"
                 mapped = True


### PR DESCRIPTION
This PR adds support for a "just an Anthropic proxy" mode that allows the proxy to pass requests directly to Anthropic models without any remapping to OpenAI or Gemini backends.

## Changes:
- **New provider option**: Added `PREFERRED_PROVIDER="anthropic"` which bypasses model remapping and passes haiku/sonnet requests directly to Anthropic with the `anthropic/` prefix
- **Updated documentation**: 
  - Updated README.md to document the new anthropic mode with usage examples
  - Updated .env.example with configuration examples and clarified that BIG_MODEL/SMALL_MODEL are ignored in anthropic mode
- **Code implementation**: Modified model validation logic in server.py to handle the anthropic provider case

## Use case:
This feature enables users who want to use the proxy infrastructure (for logging, middleware, etc.) while still using actual Anthropic models rather than being forced to remap to OpenAI or Gemini. The BIG_MODEL and SMALL_MODEL environment variables are ignored in this mode since no remapping occurs.

## Example configuration:
```env
ANTHROPIC_API_KEY="sk-ant-..."
PREFERRED_PROVIDER="anthropic"
# BIG_MODEL and SMALL_MODEL are ignored in this mode
```