### PR TITLE
Add Docker support, multi-platform CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@main
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Log in to Github's container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      # Docker images have to have lowercase names, and Github Actions doesn't
+      # have template functions
+      - name: Collect image metadata
+        id: meta
+        uses: docker/metadata-action@master
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+
+      - name: Build
+        uses: docker/build-push-action@master
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:latest
+
+WORKDIR /claude-code-proxy
+
+# Copy package specifications
+COPY pyproject.toml uv.lock ./
+
+# Install uv and project dependencies
+RUN pip install --upgrade uv && uv sync --locked
+
+# Copy project code to current directory
+COPY . .
+
+# Start the proxy
+EXPOSE 8082
+CMD uv run uvicorn server:app --host 0.0.0.0 --port 8082 --reload

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A proxy server that lets you use Anthropic clients with Gemini or OpenAI models 
 
 ### Setup 🛠️
 
+#### From source
+
 1. **Clone this repository**:
    ```bash
    git clone https://github.com/1rgs/claude-code-openai.git
@@ -52,6 +54,31 @@ A proxy server that lets you use Anthropic clients with Gemini or OpenAI models 
    uv run uvicorn server:app --host 0.0.0.0 --port 8082 --reload
    ```
    *(`--reload` is optional, for development)*
+
+#### Docker
+
+If using docker, download the example environment file to `.env` and edit it as described above.
+```bash
+curl -O .env https://raw.githubusercontent.com/1rgs/claude-code-proxy/refs/heads/main/.env.example
+```
+
+Then, you can either start the container with [docker compose](https://docs.docker.com/compose/) (preferred):
+
+```yml
+services:
+  proxy:
+    image: ghcr.io/1rgs/claude-code-proxy:latest
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - 8082:8082
+```
+
+Or with a command:
+
+```bash
+docker run -d --env-file .env -p 8082:8082 ghcr.io/1rgs/claude-code-proxy:latest
+```
 
 ### Using with Claude Code 🎮
 
@@ -100,7 +127,7 @@ The following Gemini models are supported with automatic `gemini/` prefix handli
 
 ### Model Prefix Handling
 The proxy automatically adds the appropriate prefix to model names:
-- OpenAI models get the `openai/` prefix 
+- OpenAI models get the `openai/` prefix
 - Gemini models get the `gemini/` prefix
 - The BIG_MODEL and SMALL_MODEL will get the appropriate prefix based on whether they're in the OpenAI or Gemini model lists
 


### PR DESCRIPTION
Hi there! Thanks a lot for making this project, it's been very handy for experimenting with agentic local AI. I wanted to run this proxy as a service on my cluster so I needed a basic docker image and figured I would share.

**Adds:**
 - Basic Docker installation instructions to README
 - Github Container Registry image (free for public repos)
 - Github Actions CI to build image on push (also free for public repos)
