### PR TITLE
Update available Google models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ OPENAI_BASE_URL="https://api.openai.com/v1"
 
 # Optional: Specify the exact models to map haiku/sonnet to.
 # If PREFERRED_PROVIDER=google, these MUST be valid Gemini model names known to the server.
-# Defaults to gemini-2.5-pro-preview-03-25 and gemini-2.0-flash if PREFERRED_PROVIDER=google.
+# Defaults to gemini-2.5-pro and gemini-2.5-flash if PREFERRED_PROVIDER=google.
 # Defaults to gpt-4.1 and gpt-4.1-mini if PREFERRED_PROVIDER=openai.
 # These are IGNORED when PREFERRED_PROVIDER=anthropic (models are not remapped).
 # BIG_MODEL="gpt-4.1"
@@ -20,8 +20,8 @@ OPENAI_BASE_URL="https://api.openai.com/v1"
 
 # Example Google mapping:
 # PREFERRED_PROVIDER="google"
-# BIG_MODEL="gemini-2.5-pro-preview-03-25"
-# SMALL_MODEL="gemini-2.0-flash"
+# BIG_MODEL="gemini-2.5-pro"
+# SMALL_MODEL="gemini-2.05-flash"
 
 # Example "just an Anthropic proxy" mode:
 # PREFERRED_PROVIDER="anthropic"

--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ OPENAI_BASE_URL="https://api.openai.com/v1"
 # Example Google mapping:
 # PREFERRED_PROVIDER="google"
 # BIG_MODEL="gemini-2.5-pro"
-# SMALL_MODEL="gemini-2.05-flash"
+# SMALL_MODEL="gemini-2.5-flash"
 
 # Example "just an Anthropic proxy" mode:
 # PREFERRED_PROVIDER="anthropic"

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ The following OpenAI models are supported with automatic `openai/` prefix handli
 
 #### Gemini Models
 The following Gemini models are supported with automatic `gemini/` prefix handling:
-- gemini-2.5-pro-preview-03-25
-- gemini-2.0-flash
+- gemini-2.5-pro
+- gemini-2.5-flash
 
 ### Model Prefix Handling
 The proxy automatically adds the appropriate prefix to model names:
@@ -156,8 +156,8 @@ GEMINI_API_KEY="your-google-key" # Needed if PREFERRED_PROVIDER=google
 GEMINI_API_KEY="your-google-key"
 OPENAI_API_KEY="your-openai-key" # Needed for fallback
 PREFERRED_PROVIDER="google"
-# BIG_MODEL="gemini-2.5-pro-preview-03-25" # Optional, it's the default for Google pref
-# SMALL_MODEL="gemini-2.0-flash" # Optional, it's the default for Google pref
+# BIG_MODEL="gemini-2.5-pro" # Optional, it's the default for Google pref
+# SMALL_MODEL="gemini-2.5-flash" # Optional, it's the default for Google pref
 ```
 
 **Example 3: Use Direct Anthropic ("Just an Anthropic Proxy" Mode)**


### PR DESCRIPTION
This pull request updates the references to **Google models** (changed in the code in #28), the `.env` file, and the `README`.
Until now, the documentation and the `.env` example pointed to **outdated** models that are no longer available, making it **impossible** for Claude Code to work if you followed the instructions as written.

With this pull request:

* The code, `.env` example, and `README` are now aligned with the currently available Google models.
* New users won’t get stuck with errors when trying to use the models.
* Improves clarity and ensures the project works correctly **out-of-the-box**.