### PR TITLE
Fix docker image tags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Then, you can either start the container with [docker compose](https://docs.dock
 ```yml
 services:
   proxy:
-    image: ghcr.io/1rgs/claude-code-proxy:latest
+    image: ghcr.io/1rgs/claude-code-proxy:main
     restart: unless-stopped
     env_file: .env
     ports:
@@ -82,7 +82,7 @@ services:
 Or with a command:
 
 ```bash
-docker run -d --env-file .env -p 8082:8082 ghcr.io/1rgs/claude-code-proxy:latest
+docker run -d --env-file .env -p 8082:8082 ghcr.io/1rgs/claude-code-proxy:main
 ```
 
 ### Using with Claude Code 🎮


### PR DESCRIPTION
While setting the proxy up, I bumped into missing images - turns out the tag is `main`, not `latest`